### PR TITLE
Add cancel method for a parcel

### DIFF
--- a/lib/sendcloud/parcel_resource.rb
+++ b/lib/sendcloud/parcel_resource.rb
@@ -50,6 +50,13 @@ module Sendcloud
       response['label']
     end
 
+    def cancel_parcel(parcel_id)
+      response = self.class.post("/parcels/#{parcel_id}/cancel", basic_auth: auth,
+                                header: {'Content-Type' => 'application/json'})
+      handle_response_error(response)
+      response
+    end
+
     private
       def handle_response_error(response)
         if response['error']

--- a/spec/lib/sendcloud/parcel_resource_spec.rb
+++ b/spec/lib/sendcloud/parcel_resource_spec.rb
@@ -93,4 +93,25 @@ describe Sendcloud::ParcelResource do
       end
     end
   end
+
+  context 'cancel parcel' do
+    it 'with valid parcel_id' do
+      pr = Sendcloud::ParcelResource.new('D74gAPTNto4N28N', 'Yb6m0YVBXtWm2zTdk')
+      VCR.use_cassette('cancel_parcel') do
+        parcel = pr.create_parcel(new_parcel['name'], new_parcel['shipment_address'], {id: 1}, {house_number: "123"})
+        cancel_parcel = pr.cancel_parcel(parcel['id'])
+        expect(cancel_parcel).not_to be_empty
+        expect(cancel_parcel['status']).to eql("deleted")
+      end
+    end
+
+    it 'with invalid parcel_id' do
+      pr = Sendcloud::ParcelResource.new('D74gAPTNto4N28N', 'Yb6m0YVBXtWm2zTdk')
+      VCR.use_cassette('cancel_parcel_for_parcel_with_invalid_id') do
+        parcel_id = 123456
+        expect{pr.cancel_parcel(parcel_id)}.to raise_error(Sendcloud::ParcelResourceException,
+                                                          "No Parcel matches the given query.")
+      end
+    end
+  end
 end

--- a/spec/vcr_cassettes/cancel_parcel.yml
+++ b/spec/vcr_cassettes/cancel_parcel.yml
@@ -1,0 +1,100 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://panel.sendcloud.nl/api/v2/parcels
+    body:
+      encoding: UTF-8
+      string: '{"parcel":{"name":"Rob van den Heuvel","address":"Torenallee","city":"Eindhoven","postal_code":"5617BC","country":"NL","shipment":{"id":1},"requestShipment":false,"house_number":"123"}}'
+    headers:
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic NTQyNTBmMzdjOWJjNDZiMzhhOTdiZjE5ZGI5MjE2ODg6NjQ4MDI4M2U2MzRhNDY1NTk3ZTU1ZWZmMWI2ZTcyYjU=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 15 Apr 2019 11:59:39 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '896'
+      Connection:
+      - keep-alive
+      Server:
+      - nginx
+      Vary:
+      - Accept-Encoding
+      - Cookie
+      X-Sendcloud-Client-Latest-Version-Macos:
+      - 1.0.3
+      X-Sendcloud-Client-Latest-Version-Windows:
+      - 1.0.4
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Sendcloud-Client-Latest-Version-Linux:
+      - 1.0.2
+      Allow:
+      - GET, POST, PUT, HEAD, OPTIONS
+      X-Sendcloud-Panel-Id:
+      - 48cd2d6110a253df458f3dbecfec4b8dc64680a2
+    body:
+      encoding: UTF-8
+      string: '{"parcel":{"id":21503501,"address":"Torenallee 123","address_2":"","address_divided":{"street":"Torenallee","house_number":"123"},"city":"Eindhoven","company_name":"","country":{"iso_2":"NL","iso_3":"NLD","name":"Netherlands"},"data":{},"date_created":"15-04-2019
+        11:59:39","email":"","name":"Rob van den Heuvel","postal_code":"5617BC","reference":"0","shipment":{"id":1,"name":"PostNL
+        Standard 0-30kg"},"status":{"id":999,"message":"No label"},"to_service_point":null,"telephone":"","tracking_number":"","weight":"1.000","label":{},"customs_declaration":{},"order_number":"","insured_value":0,"total_insured_value":0,"to_state":null,"customs_invoice_nr":"","customs_shipment_type":null,"parcel_items":[],"type":null,"shipment_uuid":"3c2ce417-ebb9-45cc-b5f0-b1859fb055b0","shipping_method":1,"external_order_id":"21503501","external_shipment_id":"","is_return":false,"carrier":{"code":"postnl"}}}'
+    http_version: 
+  recorded_at: Mon, 15 Apr 2019 11:59:39 GMT
+- request:
+    method: post
+    uri: https://panel.sendcloud.nl/api/v2/parcels/21503501/cancel
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Authorization:
+      - Basic NTQyNTBmMzdjOWJjNDZiMzhhOTdiZjE5ZGI5MjE2ODg6NjQ4MDI4M2U2MzRhNDY1NTk3ZTU1ZWZmMWI2ZTcyYjU=
+  response:
+    status:
+      code: 410
+      message: Gone
+    headers:
+      Date:
+      - Mon, 15 Apr 2019 11:59:39 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '56'
+      Connection:
+      - keep-alive
+      Server:
+      - nginx
+      X-Sendcloud-Client-Latest-Version-Macos:
+      - 1.0.3
+      X-Sendcloud-Client-Latest-Version-Windows:
+      - 1.0.4
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Sendcloud-Client-Latest-Version-Linux:
+      - 1.0.2
+      Allow:
+      - POST, OPTIONS
+      Vary:
+      - Cookie
+      X-Sendcloud-Panel-Id:
+      - 48cd2d6110a253df458f3dbecfec4b8dc64680a2
+    body:
+      encoding: UTF-8
+      string: '{"status":"deleted","message":"Parcel has been deleted"}'
+    http_version: 
+  recorded_at: Mon, 15 Apr 2019 11:59:39 GMT
+recorded_with: VCR 4.0.0

--- a/spec/vcr_cassettes/cancel_parcel_for_parcel_with_invalid_id.yml
+++ b/spec/vcr_cassettes/cancel_parcel_for_parcel_with_invalid_id.yml
@@ -1,0 +1,52 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://panel.sendcloud.nl/api/v2/parcels/123456/cancel
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Authorization:
+      - Basic NTQyNTBmMzdjOWJjNDZiMzhhOTdiZjE5ZGI5MjE2ODg6NjQ4MDI4M2U2MzRhNDY1NTk3ZTU1ZWZmMWI2ZTcyYjU=
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Date:
+      - Mon, 15 Apr 2019 11:48:54 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '110'
+      Connection:
+      - keep-alive
+      Server:
+      - nginx
+      X-Sendcloud-Panel-Id:
+      - 48cd2d6110a253df458f3dbecfec4b8dc64680a2
+      Vary:
+      - Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Sendcloud-Client-Latest-Version-Linux:
+      - 1.0.2
+      X-Sendcloud-Client-Latest-Version-Windows:
+      - 1.0.4
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Sendcloud-Client-Latest-Version-Macos:
+      - 1.0.3
+    body:
+      encoding: UTF-8
+      string: '{"error":{"code":404,"message":"No Parcel matches the given query.","request":"api/v2/parcels/123456/cancel"}}'
+    http_version: 
+  recorded_at: Mon, 15 Apr 2019 11:48:54 GMT
+recorded_with: VCR 4.0.0


### PR DESCRIPTION
# New feature Request

This method is used for fetching the [Cancel / Delete a parcel](https://docs.sendcloud.sc/api/v2/shipping/#cancel-delete-a-parcel) of the Sendcloud API.

**As shown in the API documentation :**
Sending a `POST` request on `https://panel.sendcloud.sc/api/v2/parcels/{id}/cancel` will cancel or delete the specific parcel. 

Considering the wrapper already has a method for creating / updating / showing a parcel, I thought it would be a good idea to implement a method for deleting a parcel. 

I hope you'll be satisfied with my code and the tests I implemented !  