### PR TITLE
replace .nl domain by .sc domain

### DIFF
--- a/lib/sendcloud/client.rb
+++ b/lib/sendcloud/client.rb
@@ -1,6 +1,6 @@
 module Sendcloud
   class Client
-    BASE_URL = "https://panel.sendcloud.nl/api/v2"
+    BASE_URL = "https://panel.sendcloud.sc/api/v2"
 
     attr_reader :api_key, :api_secret, :adapter
 


### PR DESCRIPTION
Today (26th Oct. 2022) Sendcloud API do no longer work with panel.sendcloud.nl domain. It works with panel.sendcloud.sc instead.
